### PR TITLE
Allows usage of special sprites such as _European_Union

### DIFF
--- a/src/directives/ng-flags.js
+++ b/src/directives/ng-flags.js
@@ -19,7 +19,8 @@ angular.module('ngFlag', []).
         scope.size = 16;
 
         scope.$watch('country', function(value) {
-          scope.country = angular.lowercase(value);
+          if((value !== undefined) && (value.length <= 2)) scope.country = angular.lowercase(value);
+          else scope.country = value;
         });
 
         scope.$watch('size', function(value) {


### PR DESCRIPTION
_Arab_League
_European_Union
_OPEC

without having the names turn lowercase and fail to display
